### PR TITLE
Remove dependency on standard library

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -6,6 +6,7 @@ use std::path::PathBuf;
 fn main() {
     let bindings = bindgen::Builder::default()
         .header("limine.h")
+        .use_core()
         .generate()
         .expect("Unable to generate bindings");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]


### PR DESCRIPTION
Currently, the bindings generated by Bindgen use the standard library's types (under `::std::os::raw::*`.

Projects using this crate probably won't have access to it. This pull request removes the dependency on the standard library by making the crate `#![no_std]` and by passing the `--use-core` parameter to Bindgen in the `build.rs` file.

# Notes

There might be other flags to pass to bindgen for the needs of this crate, I don't know the tool well enough to be really helpful.

For example, one could use blocklisting to avoid exporting the integer constants and types (such as `UINT_MAX` or `int_fast16_t`). I thought it was a bit weird for the crate to export those. That might be out of the scope of this PR, however, as it is clearly not backwards compatible.